### PR TITLE
Release 1.6.0.skroutz.1

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -254,7 +254,7 @@ class Redis
 
     def client
       warn("The client method is deprecated as of redis-rb 4.0.0, please use the new _client" +
-            "method instead. Support for the old method will be removed in redis-namespace 2.0.") if @has_new_client_method
+            "method instead. Support for the old method will be removed in redis-namespace 2.0.") if @has_new_client_method && deprecations?
       _client
     end
 

--- a/lib/redis/namespace/version.rb
+++ b/lib/redis/namespace/version.rb
@@ -2,6 +2,6 @@
 
 class Redis
   class Namespace
-    VERSION = '1.6.0'
+    VERSION = '1.6.0.skroutz.1'.freeze
   end
 end


### PR DESCRIPTION
This version supports properly disabling deprecation warnings regarding to redis-rb 4.X release.

The patch will be proposed to the upstream once this gets approved.


NOTE: Some tests are using the [unlink](https://redis.io/commands/unlink) command so in order to have passing tests you need a local redis instance of version 4.0.0 or later.

